### PR TITLE
Removing defaultColor Bug

### DIFF
--- a/src/color-option.js
+++ b/src/color-option.js
@@ -7,7 +7,7 @@ import Icon from './icon';
 const { width } = Dimensions.get('window');
 
 const ColorOption = (props) => {
-  const { icon, color, selectedColor, scaleToWindow, onColorChange } = props;
+  const { icon, color, isSelected, scaleToWindow, onColorChange } = props;
   let scaledWidth = width * .025;
   return (
     <TouchableOpacity
@@ -24,7 +24,7 @@ const ColorOption = (props) => {
         }
       ]}
     >
-      {selectedColor === color && <Icon color={color} icon={icon} />}
+      {isSelected  && <Icon color={color} icon={icon} />}
     </TouchableOpacity>
   );
 }
@@ -50,7 +50,7 @@ const styles = StyleSheet.create({
 ColorOption.propTypes = {
   icon: PropTypes.node,
   color: PropTypes.string.isRequired,
-  selectedColor: PropTypes.string.isRequired,
+  isSelected: PropTypes.bool.isRequired,
   scaleToWindow: PropTypes.bool.isRequired,
   onColorChange: PropTypes.func.isRequired,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -16,17 +16,16 @@ const ColorPalette = (props) => {
     titleStyles,
     value,
   } = props;
-  const [color, setColor] = useState(defaultColor || value || colors[0]);
-
+  const [color, setColor] = useState(value || defaultColor);
+  
   useEffect(() => {
-    setColor(value);
-    return () => { };
+    value && setColor(value);
   }, [value]);
 
   const onColorChange = useCallback((color) => {
     setColor(color);
     onChange(color);
-  }, []);
+  }, [onChange]);
 
   return (
     <Fragment>
@@ -39,7 +38,7 @@ const ColorPalette = (props) => {
             icon={icon}
             onColorChange={onColorChange}
             scaleToWindow={scaleToWindow}
-            selectedColor={color}
+            isSelected={value ? value ===c : color ===c}
           />
         ))}
       </View>


### PR DESCRIPTION
This is because **defaultColor** was not set correctly. And also there was few edge cases missings.

I have refracted the logic for the same and taken into few edge cases and thus now there is no warning.

Also I have removed setting defaultColor to `colors[0] ` element because the user will not have its value if selected by default.
So the apt logic would be either user provide a `defaultColor` or he uses `value`, in case of where he passes both props preference is given to `value`.